### PR TITLE
Generate .conf filename using both app name and environment

### DIFF
--- a/lib/conform_exrm.ex
+++ b/lib/conform_exrm.ex
@@ -17,7 +17,7 @@ defmodule ReleaseManager.Plugin.Conform do
 
   def before_release(%Config{name: app, version: version}) do
     relx_conf_path = Utils.rel_file_dest_path("relx.config")
-    conf_src       = Path.join([File.cwd!, "config", "#{app}.conf"])
+    conf_src       = Path.join([File.cwd!, "config", "#{app}_#{Mix.env}.conf"])
 
     debug "Conform: Loading schema..."
     schema_src = Conform.Schema.schema_path(app)

--- a/lib/conform_exrm.ex
+++ b/lib/conform_exrm.ex
@@ -42,7 +42,7 @@ defmodule ReleaseManager.Plugin.Conform do
 
       overlays = case File.exists?(conf_src) do
         true ->
-          [{:copy, '#{conf_src}', 'releases/#{version}/#{app}.conf'}|overlays]
+          [{:copy, '#{conf_src}', 'releases/#{version}/#{app}_#{Mix.env}.conf'}|overlays]
         false ->
           overlays
       end


### PR DESCRIPTION
## What

Add the Mix environment Mix.env to the .conf filename to allow for easier management of multiple environments.

Sister commit to https://github.com/bitwalker/conform/pull/61
